### PR TITLE
fix: resolve CORS/localhost issue for LAN deployments

### DIFF
--- a/backend/planty/settings.py
+++ b/backend/planty/settings.py
@@ -145,10 +145,7 @@ REST_FRAMEWORK = {
 }
 
 # CORS configuration (for development)
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",  # Vite dev server
-    "http://localhost:3000",  # Alternative frontend port
-]
+CORS_ALLOW_ALL_ORIGINS = True
 
 # WebSocket CORS configuration
 ALLOWED_HOSTS = ["*"]  # For development only

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -102,8 +102,6 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
-    environment:
-      - VITE_API_BASE_URL=http://localhost:8000/api
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api",
+  baseURL: import.meta.env.VITE_API_BASE_URL || "/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/frontend/src/api/websocket.js
+++ b/frontend/src/api/websocket.js
@@ -2,7 +2,8 @@
  * WebSocket client for real-time telemetry updates
  */
 
-const WS_BASE_URL = "ws://localhost:8000";
+const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+const WS_BASE_URL = `${protocol}//${window.location.host}`;
 
 /**
  * Create a WebSocket connection for a plant's telemetry updates

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,16 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://backend:8000',
+        changeOrigin: true,
+      },
+      '/ws': {
+        target: 'ws://backend:8000',
+        ws: true,
+      },
+    },
   },
   test: {
     globals: true,


### PR DESCRIPTION
Use Vite dev server proxy to route /api and /ws traffic to the backend internally, so the browser only talks to one origin regardless of the Pi's IP address. Drop hardcoded localhost URLs throughout.

- vite.config.js: add proxy rules for /api and /ws to backend:8000
- src/api/client.js: use relative /api base URL instead of localhost:8000
- src/api/websocket.js: derive WS host from window.location.host
- docker-compose.yaml: remove hardcoded VITE_API_BASE_URL env var
- settings.py: replace CORS_ALLOWED_ORIGINS list with CORS_ALLOW_ALL_ORIGINS